### PR TITLE
Minutes timestamp

### DIFF
--- a/typing-trainer/src/Components/History/ExerciseCard.jsx
+++ b/typing-trainer/src/Components/History/ExerciseCard.jsx
@@ -16,7 +16,12 @@ export default function ExerciseCard(props) {
   const day = dateObj.getUTCDate();
   const year = dateObj.getUTCFullYear();
   const hour = dateObj.getHours();
-  const minute = dateObj.getMinutes();
+  let minute = 0;
+  if (dateObj.getMinutes() < 10) {
+    minute = "0" + dateObj.getMinutes();
+  } else {
+    minute = dateObj.getMinutes();
+  }
 
   return (
     <div>

--- a/typing-trainer/src/Components/Home/Home.jsx
+++ b/typing-trainer/src/Components/Home/Home.jsx
@@ -143,7 +143,7 @@ export default function Home() {
     setSearch({ level: difficulty, id: iD });
   }
 
-  console.log(request);
+  // console.log(request);
   useEffect(() => {
     onSnapshot(
       doc(db, request.level, request.id),
@@ -229,9 +229,6 @@ export default function Home() {
       setUserInput("FINISHED");
 
       setHiddenVideo(true);
-
-      console.log(correctWordArray, "<<correctWordArray");
-      console.log(emotionLog.neutral, "<<neutral");
 
       if (user) {
         addDoc(exercisesRef, {


### PR DESCRIPTION
If the minutes part of the timestamp is a single digit like 10:05 then it was displaying as 10:5, fixed that and removed a couple of console logs.